### PR TITLE
Solve JsonParseException: null is not allowed as value for record com…

### DIFF
--- a/src/main/java/org/mfusco/PersonExtractor.java
+++ b/src/main/java/org/mfusco/PersonExtractor.java
@@ -4,7 +4,7 @@ import dev.langchain4j.service.UserMessage;
 
 public interface PersonExtractor {
 
-    @UserMessage("Extract information about a person from {{it}}")
+    @UserMessage("Extract information about a person from {{it}}. When income is null, it is set to 0.")
     Person extractPersonFrom(String text);
 }
 


### PR DESCRIPTION
…ponent 'income' of primitive type; at path $.income

When I put the message `Sofia, the daughter of Mario Fusco, is born on the twentysixth day of the ninth month of 2011. She is a very smart student.`, I get the error,
```
Exception in thread "main" com.google.gson.JsonParseException: null is not allowed as value for record component 'income' of primitive type; at path $.income
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.readIntoArray(ReflectiveTypeAdapterFactory.java:204)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$RecordAdapter.readField(ReflectiveTypeAdapterFactory.java:509)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$RecordAdapter.readField(ReflectiveTypeAdapterFactory.java:442)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:393)
	at com.google.gson.Gson.fromJson(Gson.java:1227)
	at com.google.gson.Gson.fromJson(Gson.java:1137)
	at com.google.gson.Gson.fromJson(Gson.java:1047)
	at com.google.gson.Gson.fromJson(Gson.java:982)
	at dev.langchain4j.internal.Json.fromJson(Json.java:42)
	at dev.langchain4j.service.ServiceOutputParser.parse(ServiceOutputParser.java:87)
	at dev.langchain4j.service.AiServices$1.invoke(AiServices.java:433)
	at jdk.proxy2/jdk.proxy2.$Proxy5.extractPersonFrom(Unknown Source)
	at org.mfusco.MortgageChat.extractPerson(MortgageChat.java:40)
	at org.mfusco.MortgageChat.chat(MortgageChat.java:36)
	at org.mfusco.Main.main(Main.java:27)
```

This error occurs only after introducing `record`.

Anyway, it's fun to fix just by `@UserMessage`.